### PR TITLE
Specify extension context type for QuestionnaireResponseContext

### DIFF
--- a/input/fsh/extensions.fsh
+++ b/input/fsh/extensions.fsh
@@ -3,7 +3,8 @@ Extension: QuestionnaireResponseContext
 Id: qr-context
 Description: "Identifies the orders, coverages, and or other resources associated with the specified QuestionnaireResponse.  Allows finding the DTR responses associated with a particular Order/Encounter/Appointment for a particular insurance coverage."
 * ^title = "Questionnaire Response Context"
-* ^context.expression = "QuestionnaireResponse"
+* ^context[0].type = #element
+* ^context[=].expression = "QuestionnaireResponse"
 * ^status = #active
 * value[x] 1..1
 * value[x] only Reference($CRDCoverage or $CRDDeviceRequest or $CRDMedicationRequest or $CRDNutritionOrder or $CRDServiceRequest or $CRDEncounter or $CRDAppointment)


### PR DESCRIPTION
The `QuestionnaireResponseContext` extension previously only set the `^context.expression`, but did not set the `^context.type`. This went unnoticed due to the way SUSHI handled contexts (i.e., it ended up w/ a default type of `#element`). The next version of SUSHI changes how it handles contexts and this unintentional behavior (of automatically setting `^context.type` to `#element`) will no longer work.

This PR updates the FSH to set the `^context.type` as well. If you look at the other extensions in `extensions.fsh`, you'll notice that they already do this. This PR just updates `QuestionnaireResponseContext` to follow the same pattern as the other extension definitions already followed.

_Extra Note: The FSH 3.0 ballot introduced a new `Context:` keyword for setting contexts. I have not used it here, but it is something you should consider. It will be in FSH 3.0 and SUSHI already supports it. See the documentation in the [FSH 3.0 ballot](https://hl7.org/fhir/uv/shorthand/2023Sep/reference.html#defining-extensions)._